### PR TITLE
Fixed zfsencryptssh initcpio install file URL

### DIFF
--- a/testing/helpers/chroot-arch.sh
+++ b/testing/helpers/chroot-arch.sh
@@ -60,7 +60,7 @@ zfsutils="https://raw.githubusercontent.com/archzfs/archzfs/master/src/zfs-utils
 cpiolib="/usr/lib/initcpio"
 curl -L -o "${cpiolib}/hooks/zfs" "${zfsutils}/zfs-utils.initcpio.hook"
 curl -L -o "${cpiolib}/install/zfs" "${zfsutils}/zfs-utils.initcpio.install"
-curl -L -o "${cpiolib}/install/zfsencryptssh" "${zfsutils}/zfs-utils.initcpio.zfsncrypt.sshinstall"
+curl -L -o "${cpiolib}/install/zfsencryptssh" "${zfsutils}/zfs-utils.initcpio.zfsencryptssh.install"
 
 # Arch doesn't play nicely with the pre-existing cache
 rm -f /etc/zfs/zpool.cache


### PR DESCRIPTION
Fixed the URL for the ArchLinux testing script initcpio `install` file.